### PR TITLE
Refactor to enable nuget signing

### DIFF
--- a/EsrpSign.yml
+++ b/EsrpSign.yml
@@ -14,55 +14,16 @@ steps:
   inputs:
     version: 2.x
 
-- pwsh: |
-    [string] $CertificateId = "${{ parameters.certificateId }}"
-    Write-Verbose "CertificateId - $CertificateId" -Verbose
+- template: template-compliance/authenticode-sign.yml
+  parameters:
+    buildOutputPath: ${{ parameters.buildOutputPath }}
+    signOutputPath: ${{ parameters.signOutputPath }}
+    pattern: ${{ parameters.pattern }}
+    certificateId: ${{ parameters.certificateId }}
+  condition: or(eq('${{ parameters.certificateId }}', 'CP-230012'), eq('${{ parameters.certificateId }}', 'CP-231522'))
 
-    [string] $VariableName = "EsrpJson"
-
-    [string] $SigningServer = '$(SigningServer)'
-    Write-Verbose "SigningServer - $SigningServer" -Verbose
-
-    $esrpParameters = @(
-    @{
-        ParameterName  = "OpusName"
-        ParameterValue = "Microsoft"
-    }
-    @{
-        ParameterName  = "OpusInfo"
-        ParameterValue = "http://www.microsoft.com"
-    }
-    @{
-        ParameterName  = "PageHash"
-        ParameterValue = "/NPH"
-    }
-    @{
-        ParameterName  = "FileDigest"
-        ParameterValue = "/fd sha256"
-    }
-    @{
-        ParameterName  = "TimeStamp"
-        ParameterValue = "/tr ""$SigningServer"" /td sha256"
-    }
-    )
-
-    $esrp = @(@{
-    keyCode = $CertificateId
-    operationSetCode = "SigntoolSign"
-    parameters = $esrpParameters
-    toolName = "signtool.exe"
-    toolVersion = "6.2.9304.0"
-    })
-
-    $vstsCommandString = "vso[task.setvariable variable=$VariableName][$($esrp | ConvertTo-Json -Compress)]"
-    Write-Verbose -Message ("sending " + $vstsCommandString) -Verbose
-    Write-Host "##$vstsCommandString"
-
-    $vstsCommandString = "vso[task.setvariable variable=GDN_CODESIGN_TARGETDIRECTORY]${{ parameters.signOutputPath }}"
-    Write-Verbose -Message ("sending " + $vstsCommandString) -Verbose
-    Write-Host "##$vstsCommandString"
-  displayName: Generate signing JSON
-  condition: and(and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True')), ne(variables['SigningServer'], ''))
+- template: template-compliance/nuget-sign.yml
+  condition: eq('${{ parameters.certificateId }}', 'CP-401405')
 
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: Sign files
@@ -83,4 +44,4 @@ steps:
   displayName: Copy signed files to signed output directory
   condition: and(and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True')), ne(variables['SigningServer'], ''))
   timeoutInMinutes: 10
-  
+

--- a/template-compliance/authenticode-sign.yml
+++ b/template-compliance/authenticode-sign.yml
@@ -1,0 +1,60 @@
+parameters:
+  - name: "buildOutputPath"
+    default: "$(Build.ArtifactStagingDirectory)\\build"
+  - name: "signOutputPath"
+    default: "$(Build.ArtifactStagingDirectory)\\signed"
+  - name: "pattern"
+    default: "*.dll,*.exe"
+  - name: "certificateId"
+    default: "CP-230012"
+
+steps:
+- pwsh: |
+    [string] $CertificateId = "${{ parameters.certificateId }}"
+    Write-Verbose "CertificateId - $CertificateId" -Verbose
+
+    [string] $VariableName = "EsrpJson"
+
+    [string] $SigningServer = '$(SigningServer)'
+    Write-Verbose "SigningServer - $SigningServer" -Verbose
+
+    $esrpParameters = @(
+    @{
+        ParameterName  = "OpusName"
+        ParameterValue = "Microsoft"
+    }
+    @{
+        ParameterName  = "OpusInfo"
+        ParameterValue = "http://www.microsoft.com"
+    }
+    @{
+        ParameterName  = "PageHash"
+        ParameterValue = "/NPH"
+    }
+    @{
+        ParameterName  = "FileDigest"
+        ParameterValue = "/fd sha256"
+    }
+    @{
+        ParameterName  = "TimeStamp"
+        ParameterValue = "/tr ""$SigningServer"" /td sha256"
+    }
+    )
+
+    $esrp = @(@{
+    keyCode = $CertificateId
+    operationSetCode = "SigntoolSign"
+    parameters = $esrpParameters
+    toolName = "signtool.exe"
+    toolVersion = "6.2.9304.0"
+    })
+
+    $vstsCommandString = "vso[task.setvariable variable=$VariableName][$($esrp | ConvertTo-Json -Compress)]"
+    Write-Verbose -Message ("sending " + $vstsCommandString) -Verbose
+    Write-Host "##$vstsCommandString"
+
+    $vstsCommandString = "vso[task.setvariable variable=GDN_CODESIGN_TARGETDIRECTORY]${{ parameters.signOutputPath }}"
+    Write-Verbose -Message ("sending " + $vstsCommandString) -Verbose
+    Write-Host "##$vstsCommandString"
+  displayName: Generate signing JSON
+  condition: and(and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True')), ne(variables['SigningServer'], ''))

--- a/template-compliance/nuget-sign.yml
+++ b/template-compliance/nuget-sign.yml
@@ -1,0 +1,41 @@
+parameters:
+  - name: "buildOutputPath"
+    default: "$(Build.ArtifactStagingDirectory)\\build"
+  - name: "signOutputPath"
+    default: "$(Build.ArtifactStagingDirectory)\\signed"
+  - name: "pattern"
+    default: "*.nupkg"
+  - name: "certificateId"
+    default: "CP-401405"
+
+steps:
+- pwsh: |
+    [string] $CertificateId = "${{ parameters.certificateId }}"
+    Write-Verbose "CertificateId - $CertificateId" -Verbose
+
+    [string] $VariableName = "EsrpJson"
+
+    $esrp = @(
+        @{
+         keyCode = $CertificateId
+         operationSetCode = "NuGetSign"
+         toolName = "sign"
+         toolVersion = "1.0"
+        },
+        @{
+          keyCode = $CertificateId
+          operationSetCode = "NuGetVerify"
+          toolName = "sign"
+          toolVersion = "1.0"
+        }
+    )
+
+    $vstsCommandString = "vso[task.setvariable variable=$VariableName][$($esrp | ConvertTo-Json -Compress)]"
+    Write-Verbose -Message ("sending " + $vstsCommandString) -Verbose
+    Write-Host "##$vstsCommandString"
+
+    $vstsCommandString = "vso[task.setvariable variable=GDN_CODESIGN_TARGETDIRECTORY]${{ parameters.signOutputPath }}"
+    Write-Verbose -Message ("sending " + $vstsCommandString) -Verbose
+    Write-Host "##$vstsCommandString"
+  displayName: Generate signing JSON
+  condition: and(and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True')), ne(variables['SigningServer'], ''))


### PR DESCRIPTION
Refactor the ESRP yaml to include two templates for authenticode and nuget signing. They have conditions to switch based on certificate ID