### PR TITLE
Remove duplicate calls to Authenticode template

### DIFF
--- a/EsrpSign.yml
+++ b/EsrpSign.yml
@@ -80,26 +80,6 @@ steps:
     pageHash: ${{ parameters.pageHash }}
     displayName: ${{ parameters.displayName }}
 
-- template: template-compliance/authenticode-sign.yml
-  parameters:
-    buildOutputPath: ${{ parameters.buildOutputPath }}
-    signOutputPath: ${{ parameters.signOutputPath }}
-    pattern: ${{ parameters.pattern }}
-    certificateId: ${{ parameters.certificateId }}
-    verifySignature: ${{ parameters.verifySignature }}
-    pageHash: ${{ parameters.pageHash }}
-    displayName: ${{ parameters.displayName }}
-
-- template: template-compliance/authenticode-sign.yml
-  parameters:
-    buildOutputPath: ${{ parameters.buildOutputPath }}
-    signOutputPath: ${{ parameters.signOutputPath }}
-    pattern: ${{ parameters.pattern }}
-    certificateId: ${{ parameters.certificateId }}
-    verifySignature: ${{ parameters.verifySignature }}
-    pageHash: ${{ parameters.pageHash }}
-    displayName: ${{ parameters.displayName }}
-
 - template: template-compliance/nuget-sign.yml
   parameters:
     buildOutputPath: ${{ parameters.buildOutputPath }}


### PR DESCRIPTION
After we move the condition logic into the template we only need to call this once.