### PR TITLE
Remove defender template from compliance templates

### DIFF
--- a/assembly-module-compliance.yml
+++ b/assembly-module-compliance.yml
@@ -43,8 +43,6 @@ steps:
   parameters:
     suppressionsFile: ${{ parameters.suppressionsFile }}
 
-- template: template-compliance/defender.yml
-
 - template: template-compliance/TermCheck.yml
   parameters:
     targetArgument: ${{ parameters.targetArgument }}

--- a/script-module-compliance.yml
+++ b/script-module-compliance.yml
@@ -24,8 +24,6 @@ steps:
   parameters:
     suppressionsFile: ${{ parameters.suppressionsFile }}
 
-- template: template-compliance/defender.yml
-
 - template: template-compliance/TermCheck.yml
   parameters:
     targetArgument: ${{ parameters.targetArgument }}


### PR DESCRIPTION
The task the defender template runs consistently fails, causing build pipelines to fail. @TravisEz13 says that we do not need to run it, so we're removing it from the top-level templates here.