### PR TITLE
Allow pass in the connection string to APIScan task

### DIFF
--- a/assembly-module-compliance.yml
+++ b/assembly-module-compliance.yml
@@ -3,6 +3,7 @@ parameters:
   softwareFolder: ''
   softwareName: ''
   softwareVersion: ''
+  connectionString: ''
   # binskim
   AnalyzeTarget: ''
   AnalyzeSymPath: 'SRV*'
@@ -26,6 +27,7 @@ steps:
     softwareFolder: ${{ parameters.softwareFolder }}
     softwareName: ${{ parameters.softwareName }}
     softwareVersion: ${{ parameters.softwareVersion }}
+    connectionString: ${{ parameters.connectionString }}
     APIScanEnable: ${{ parameters.APIScan }}
 
 - template: template-compliance/auto-applicability.yml

--- a/template-compliance/apiscan.yml
+++ b/template-compliance/apiscan.yml
@@ -2,6 +2,7 @@ parameters:
   softwareFolder: ''
   softwareName: ''
   softwareVersion: ''
+  connectionString: ''
   APIScanEnable: ''
 
 steps:
@@ -14,4 +15,6 @@ steps:
       softwareVersionNum: ${{ parameters.softwareVersion }}
       isLargeApp: false
       preserveTempFiles: true
+    env:
+      AzureServicesAuthConnectionString: ${{ parameters.connectionString }}
     continueOnError: true


### PR DESCRIPTION
The API Scan task needs the pipeline to provide the authentication connection string, so update the yaml file to allow the connection string to be passed in.