### PR TITLE
Change esrp parameters value to empty hashtable

### DIFF
--- a/template-compliance/strongname-sign.yml
+++ b/template-compliance/strongname-sign.yml
@@ -27,7 +27,7 @@ steps:
     $esrp = @(@{
       keyCode       = $CertificateId
       operationCode = "StrongNameSign"
-      parameters    = {}
+      parameters    = @{}
       toolName      = "sign"
       toolVersion   = "1.0"
     })


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
PackageManagement could not be properly strong name signed.  After some debugging with @TravisEz13 we discovered that the esrp array of hashtables has a key named `parameters` that should be a hashtable.  This PR just adds an `@` to create an empty hashtable.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
PackageManagement needs to be strong name signed and is only able to be properly signed with this fix. 