### PR TITLE
Enable comment scanning with PoliCheck

### DIFF
--- a/template-compliance/TermCheck.yml
+++ b/template-compliance/TermCheck.yml
@@ -10,7 +10,7 @@ steps:
   inputs:
     targetType: F
     targetArgument: ${{ parameters.targetArgument }}
-    optionsFC: 0
+    optionsFC: 1
     optionsPE: '1|2|3|4'
     optionsHMENABLE: 0
     optionsUEPATH: ${{ parameters.optionsUEPATH }}


### PR DESCRIPTION
The template has this disabled but @TravisEz13 says it's supposed to be enabled.